### PR TITLE
Modify the issue of extracting feature points at the edges of the gripper mask.

### DIFF
--- a/Examples/Monocular-Inertial/gopro_slam.cc
+++ b/Examples/Monocular-Inertial/gopro_slam.cc
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
   std::string save_map;
   app.add_option("--save_map", save_map);
 
-  bool enable_gui = false;
+  bool enable_gui = true;
   app.add_flag("-g,--enable_gui", enable_gui);
 
   int num_threads = 4;
@@ -216,7 +216,8 @@ int main(int argc, char **argv) {
     bool success = cap.read(im);
     if (!success) {
       cout << "cap.read failed!" << endl;
-      break;
+      //break;
+      continue;
     }
 
     // resize image and draw gripper mask
@@ -226,9 +227,9 @@ int main(int argc, char **argv) {
     }
 
     // apply mask image if loaded
-    if (!mask_img.empty()) {
-      im_track.setTo(cv::Scalar(0,0,0), mask_img);
-    }
+    // if (!mask_img.empty()) {
+    //   im_track.setTo(cv::Scalar(0,0,0), mask_img);
+    // }
 
     // gather imu measurements between frames
     // Load imu measurements from previous frame
@@ -245,8 +246,8 @@ int main(int argc, char **argv) {
         std::chrono::steady_clock::now();
 
     // Pass the image to the SLAM system
-    auto result = SLAM.LocalizeMonocular(im_track, tframe, vImuMeas);
-
+    // auto result = SLAM.LocalizeMonocular(im_track, tframe, vImuMeas); 
+    auto result = SLAM.LocalizeMonocular(im_track, mask_img, tframe, vImuMeas);
     // check lost frames
     if (! result.second){
         n_lost_frames += 1;

--- a/Examples/Monocular-Inertial/gopro_slam.cc
+++ b/Examples/Monocular-Inertial/gopro_slam.cc
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
   std::string save_map;
   app.add_option("--save_map", save_map);
 
-  bool enable_gui = true;
+  bool enable_gui = false;
   app.add_flag("-g,--enable_gui", enable_gui);
 
   int num_threads = 4;
@@ -216,8 +216,7 @@ int main(int argc, char **argv) {
     bool success = cap.read(im);
     if (!success) {
       cout << "cap.read failed!" << endl;
-      //break;
-      continue;
+      break;
     }
 
     // resize image and draw gripper mask

--- a/include/Frame.h
+++ b/include/Frame.h
@@ -68,6 +68,8 @@ public:
     // Constructor for Monocular cameras.
     Frame(const cv::Mat &imGray, const double &timeStamp, ORBextractor* extractor,ORBVocabulary* voc, GeometricCamera* pCamera, cv::Mat &distCoef, const float &bf, const float &thDepth, Frame* pPrevF = static_cast<Frame*>(NULL), const IMU::Calib &ImuCalib = IMU::Calib(), cv::Ptr<cv::aruco::Dictionary> aruco_dict=cv::aruco::getPredefinedDictionary(cv::aruco::DICT_4X4_50));
 
+    Frame(const cv::Mat &imGray,const cv::Mat& mask, const double &timeStamp, ORBextractor* extractor,ORBVocabulary* voc, GeometricCamera* pCamera, cv::Mat &distCoef, const float &bf, const float &thDepth, Frame* pPrevF = static_cast<Frame*>(NULL), const IMU::Calib &ImuCalib = IMU::Calib(), cv::Ptr<cv::aruco::Dictionary> aruco_dict=cv::aruco::getPredefinedDictionary(cv::aruco::DICT_4X4_50));
+
     // Destructor
     // ~Frame();
 

--- a/include/System.h
+++ b/include/System.h
@@ -132,6 +132,8 @@ public:
     // Returns the camera pose (empty if tracking fails).
     std::pair<Sophus::SE3f, bool> LocalizeMonocular(const cv::Mat &im, const double &timestamp, const vector<IMU::Point>& vImuMeas = vector<IMU::Point>(), string filename="");
 
+    std::pair<Sophus::SE3f, bool> LocalizeMonocular(const cv::Mat &im,const cv::Mat &mask, const double &timestamp, const vector<IMU::Point>& vImuMeas= vector<IMU::Point>(), string filename="");
+
     // This stops local mapping thread (map building) and performs only camera tracking.
     void ActivateLocalizationMode();
     // This resumes local mapping thread and performs SLAM again.

--- a/include/Tracking.h
+++ b/include/Tracking.h
@@ -75,6 +75,7 @@ public:
     Sophus::SE3f GrabImageStereo(const cv::Mat &imRectLeft,const cv::Mat &imRectRight, const double &timestamp, string filename);
     Sophus::SE3f GrabImageRGBD(const cv::Mat &imRGB,const cv::Mat &imD, const double &timestamp, string filename);
     Sophus::SE3f GrabImageMonocular(const cv::Mat &im, const double &timestamp, string filename);
+    Sophus::SE3f GrabImageMonocular(const cv::Mat &im, const cv::Mat &mask, const double &timestamp, string filename);
 
     void GrabImuData(const IMU::Point &imuMeasurement);
 

--- a/src/System.cc
+++ b/src/System.cc
@@ -518,6 +518,86 @@ std::pair<Sophus::SE3f, bool> System::LocalizeMonocular(const cv::Mat &im, const
     return std::make_pair(Tcw, has_tracking);
 }
 
+std::pair<Sophus::SE3f, bool> System::LocalizeMonocular(const cv::Mat &im,const cv::Mat &mask, const double &timestamp, const vector<IMU::Point>& vImuMeas, string filename)
+{
+
+    {
+        unique_lock<mutex> lock(mMutexReset);
+        if(mbShutDown)
+            return std::make_pair(Sophus::SE3f(), false);
+    }
+
+    if(mSensor!=MONOCULAR && mSensor!=IMU_MONOCULAR)
+    {
+        cerr << "ERROR: you called TrackMonocular but input sensor was not set to Monocular nor Monocular-Inertial." << endl;
+        exit(-1);
+    }
+
+    cv::Mat imToFeed = im.clone();
+    if(settings_ && settings_->needToResize()){
+        cv::Mat resizedIm;
+        cv::resize(im,resizedIm,settings_->newImSize());
+        imToFeed = resizedIm;
+    }
+
+    // Check mode change
+    {
+        unique_lock<mutex> lock(mMutexMode);
+        if(mbActivateLocalizationMode)
+        {
+            mpLocalMapper->RequestStop();
+
+            // Wait until Local Mapping has effectively stopped
+            while(!mpLocalMapper->isStopped())
+            {
+                usleep(1000);
+            }
+
+            mpTracker->InformOnlyTracking(true);
+            mbActivateLocalizationMode = false;
+        }
+        if(mbDeactivateLocalizationMode)
+        {
+            mpTracker->InformOnlyTracking(false);
+            mpLocalMapper->Release();
+            mbDeactivateLocalizationMode = false;
+        }
+    }
+
+    // Check reset
+    {
+        unique_lock<mutex> lock(mMutexReset);
+        if(mbReset)
+        {
+            mpTracker->Reset();
+            mbReset = false;
+            mbResetActiveMap = false;
+        }
+        else if(mbResetActiveMap)
+        {
+            cout << "SYSTEM-> Reseting active map in monocular case" << endl;
+            mpTracker->ResetActiveMap();
+            mbResetActiveMap = false;
+        }
+    }
+
+    if (mSensor == System::IMU_MONOCULAR)
+        for(size_t i_imu = 0; i_imu < vImuMeas.size(); i_imu++)
+            mpTracker->GrabImuData(vImuMeas[i_imu]);
+
+    Sophus::SE3f Tcw = mpTracker->GrabImageMonocular(imToFeed,mask,timestamp,filename);
+    int trackingState = mpTracker->mState;
+    // has tracking for OK and RECENTLY_LOST state.
+    bool has_tracking = (trackingState == 2) || (trackingState == 3);
+    // bool has_tracking = trackingState == 2;
+
+    unique_lock<mutex> lock2(mMutexState);
+    mTrackingState = mpTracker->mState;
+    mTrackedMapPoints = mpTracker->mCurrentFrame.mvpMapPoints;
+    mTrackedKeyPointsUn = mpTracker->mCurrentFrame.mvKeysUn;
+
+    return std::make_pair(Tcw, has_tracking);
+}
 
 void System::ActivateLocalizationMode()
 {

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -1202,6 +1202,56 @@ Sophus::SE3f Tracking::GrabImageMonocular(const cv::Mat &im, const double &times
     return mCurrentFrame.GetPose();
 }
 
+Sophus::SE3f Tracking::GrabImageMonocular(const cv::Mat &im,const cv::Mat &mask, const double &timestamp, string filename)
+{
+    mImGray = im;
+    if(mImGray.channels()==3)
+    {
+        if(mbRGB)
+            cvtColor(mImGray,mImGray,cv::COLOR_RGB2GRAY);
+        else
+            cvtColor(mImGray,mImGray,cv::COLOR_BGR2GRAY);
+    }
+    else if(mImGray.channels()==4)
+    {
+        if(mbRGB)
+            cvtColor(mImGray,mImGray,cv::COLOR_RGBA2GRAY);
+        else
+            cvtColor(mImGray,mImGray,cv::COLOR_BGRA2GRAY);
+    }
+
+    if (mSensor == System::MONOCULAR)
+    {
+        if(mState==NOT_INITIALIZED || mState==NO_IMAGES_YET ||(lastID - initID) < mMaxFrames)
+            mCurrentFrame = Frame(mImGray,timestamp,mpIniORBextractor,mpORBVocabulary,mpCamera,mDistCoef,mbf,mThDepth);
+        else
+            mCurrentFrame = Frame(mImGray,timestamp,mpORBextractorLeft,mpORBVocabulary,mpCamera,mDistCoef,mbf,mThDepth);
+    }
+    else if(mSensor == System::IMU_MONOCULAR)
+    {
+        // std::cout<< "mState: " << mState << std::endl;
+        if(mState==NOT_INITIALIZED || mState==NO_IMAGES_YET)
+        {
+            mCurrentFrame = Frame(mImGray,mask,timestamp,mpIniORBextractor,mpORBVocabulary,mpCamera,mDistCoef,mbf,mThDepth,&mLastFrame,*mpImuCalib, maruco_dict);
+        }
+        else{
+            mCurrentFrame = Frame(mImGray,mask,timestamp,mpORBextractorLeft,mpORBVocabulary,mpCamera,mDistCoef,mbf,mThDepth,&mLastFrame,*mpImuCalib, maruco_dict);
+        }
+    }
+    
+
+    if (mState==NO_IMAGES_YET)
+        t0=timestamp;
+
+    mCurrentFrame.mNameFile = filename;
+    mCurrentFrame.mnDataset = mnNumDataset;
+
+    lastID = mCurrentFrame.mnId;
+
+    Track();
+
+    return mCurrentFrame.GetPose();
+}
 
 void Tracking::GrabImuData(const IMU::Point &imuMeasurement)
 {


### PR DESCRIPTION
The gripper is a moving object, so the generated mask moves along with it. Feature points are easily generated at the edges of the mask, which affects the robustness of ORBSLAM3. Therefore, the feature point selection method has been modified to avoid tracking feature points located at the edges of the gripper mask.